### PR TITLE
Fix issue with `String#contains`

### DIFF
--- a/lib/seeing-is-believing.coffee
+++ b/lib/seeing-is-believing.coffee
@@ -56,7 +56,7 @@ module.exports =
 
     sib.on 'close', (code) =>
       console.log('Seeing is Believing closed with code ' + code)
-      if capturedError.contains('LoadError')
+      if capturedError.includes('LoadError')
         alert("It looks like the Seeing is Believing gem hasn't been installed, run\n`gem install seeing is believing`\nto do so, then make sure it worked with\n`seeing_is_believing --version`\n\nIf it should be installed, check logs to see what was executed\n(Option+Command+I)")
       else if code == 2 # nondisplayable error
         alert(capturedError)


### PR DESCRIPTION
Atom seems to like `String#includes` over `String#contains` all of a sudden on my install. If you can verify this is a problem for others, here's the change. Closes #13 